### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   "license": "MPL-2.0",
   "devDependencies": {
     "it-pipe": "^1.1.0",
-    "mocha": "^7.1.1",
-    "streaming-iterables": "^4.1.2"
+    "mocha": "^8.3.2",
+    "streaming-iterables": "^5.0.4"
   },
   "dependencies": {
-    "bl": "^4.0.2",
-    "buffer": "^5.5.0"
+    "bl": "^5.0.0",
+    "buffer": "^6.0.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updates all deps to pull in new buffer version and prevent bloat
of browser bundles.

BREAKING CHANGE: buffer@6 drops support for ie11 and safari < 10